### PR TITLE
Fix preprocessor directives in cros.h

### DIFF
--- a/include/cros.h
+++ b/include/cros.h
@@ -20,8 +20,8 @@ extern "C"
 #include "cros_log.h"
 #include "cros_clock.h"
 
-#endif /* INCLUDE_CROS_H_ */
-
 #ifdef __cplusplus
 }
 #endif
+
+#endif /* INCLUDE_CROS_H_ */


### PR DESCRIPTION
Fixed preprocessor directive in cros.h to protect the header correctly